### PR TITLE
Global overlay fix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 # https://github.com/prettier/prettier#configuration-file
 semi: true
 singleQuote: true
+trailingComma: "none"
 overrides:
 - files: ".prettierrc"
   options:

--- a/src/Overlay/GlobalOverlay.tsx
+++ b/src/Overlay/GlobalOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, useEffect } from 'react';
 import { GlobalOverlayCommon, useGlobalOverlay } from './useGlobalOverlay';
 
 export interface GlobalOverlayProps extends GlobalOverlayCommon {
@@ -20,24 +20,12 @@ export const GlobalOverlay: FC<GlobalOverlayProps> = ({
     overlayIndex,
     portalIndex,
     setOpen,
-    isOpen
-  } = useGlobalOverlay(rest);
-  const mounted = useRef<boolean>(false);
+  } = useGlobalOverlay({ onClose, ...rest });
   const renderFn = children || render;
 
   useEffect(() => {
     setOpen(open);
   }, [open]);
-
-  useEffect(() => {
-    if (mounted.current) {
-      if (!isOpen) {
-        onClose && onClose();
-      }
-    } else {
-      mounted.current = true;
-    }
-  }, [isOpen]);
 
   return <Component>{() => renderFn({ overlayIndex, portalIndex })}</Component>;
 };

--- a/src/Overlay/Overlay.story.tsx
+++ b/src/Overlay/Overlay.story.tsx
@@ -14,7 +14,7 @@ storiesOf('Utilities|Overlay/Portal', module)
     <div
       style={{
         width: 300,
-        height: 300
+        height: 300,
       }}
     >
       <div
@@ -24,7 +24,7 @@ storiesOf('Utilities|Overlay/Portal', module)
           background: 'black',
           padding: 50,
           position: 'relative',
-          overflow: 'hidden'
+          overflow: 'hidden',
         }}
       >
         Hello
@@ -49,7 +49,7 @@ storiesOf('Utilities|Overlay/Portal', module)
           background: 'black',
           padding: 50,
           position: 'relative',
-          overflow: 'hidden'
+          overflow: 'hidden',
         }}
       >
         Hello!
@@ -61,48 +61,14 @@ storiesOf('Utilities|Overlay/Portal', module)
   });
 
 storiesOf('Utilities|Overlay/Global', module)
-  .add('Auto Open', () => (
-    <div
-      style={{
-        width: 300,
-        height: 300
-      }}
-    >
-      <div
-        style={{
-          width: 300,
-          height: 300,
-          background: 'black',
-          padding: 50,
-          position: 'relative',
-          overflow: 'hidden'
-        }}
-      >
-        Hello
-        <GlobalOverlay open={true}>
-          {({ overlayIndex }) => (
-            <div
-              style={{
-                background: 'blue',
-                zIndex: overlayIndex,
-                position: 'absolute'
-              }}
-            >
-              Hi - {overlayIndex}
-            </div>
-          )}
-        </GlobalOverlay>
-      </div>
-    </div>
-  ))
-  .add('Click to open', () => {
-    const [open, setOpen] = useState(false);
+  .add('Auto Open', () => {
+    const [open, setOpen] = useState(true);
 
     return (
       <div
         style={{
           width: 300,
-          height: 300
+          height: 300,
         }}
       >
         <div
@@ -112,7 +78,45 @@ storiesOf('Utilities|Overlay/Global', module)
             background: 'black',
             padding: 50,
             position: 'relative',
-            overflow: 'hidden'
+            overflow: 'hidden',
+          }}
+        >
+          Hello
+          <GlobalOverlay open={open} onClose={() => setOpen(false)}>
+            {({ overlayIndex }) => (
+              <div
+                style={{
+                  background: 'blue',
+                  zIndex: overlayIndex,
+                  position: 'absolute',
+                }}
+              >
+                Hi - {overlayIndex}
+              </div>
+            )}
+          </GlobalOverlay>
+        </div>
+      </div>
+    );
+  })
+  .add('Click to open', () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div
+        style={{
+          width: 300,
+          height: 300,
+        }}
+      >
+        <div
+          style={{
+            width: 300,
+            height: 300,
+            background: 'black',
+            padding: 50,
+            position: 'relative',
+            overflow: 'hidden',
           }}
         >
           <button type="button" onClick={() => setOpen(true)}>
@@ -128,7 +132,56 @@ storiesOf('Utilities|Overlay/Global', module)
                 style={{
                   background: 'blue',
                   zIndex: overlayIndex,
-                  position: 'absolute'
+                  position: 'absolute',
+                }}
+              >
+                Hi - {overlayIndex}
+              </div>
+            )}
+          </GlobalOverlay>
+        </div>
+      </div>
+    );
+  })
+  .add('Prompt to close', () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div
+        style={{
+          width: 300,
+          height: 300,
+        }}
+      >
+        <div
+          style={{
+            width: 300,
+            height: 300,
+            background: 'black',
+            padding: 50,
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <GlobalOverlay
+            open={open}
+            closeOnBackdropClick={true}
+            onClose={() => {
+              const ok = window.confirm('Are you sure you want to close?');
+              if (ok) {
+                setOpen(false);
+              }
+            }}
+          >
+            {({ overlayIndex }) => (
+              <div
+                style={{
+                  background: 'blue',
+                  zIndex: overlayIndex,
+                  position: 'absolute',
                 }}
               >
                 Hi - {overlayIndex}
@@ -140,7 +193,9 @@ storiesOf('Utilities|Overlay/Global', module)
     );
   })
   .add('Hooks', () => {
-    const { GlobalOverlay, setOpen, overlayIndex } = useGlobalOverlay();
+    const { GlobalOverlay, setOpen, overlayIndex } = useGlobalOverlay({
+      onClose: () => setOpen(false),
+    });
 
     return (
       <Fragment>
@@ -154,7 +209,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 background: 'blue',
                 padding: 25,
                 zIndex: overlayIndex as number,
-                position: 'fixed'
+                position: 'fixed',
               }}
             >
               Hello!
@@ -174,7 +229,7 @@ storiesOf('Utilities|Overlay/Global', module)
             style={{
               display: 'flex',
               justifyContent: 'center',
-              alignItems: 'center'
+              alignItems: 'center',
             }}
           >
             <motion.div
@@ -188,7 +243,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 top: 50,
                 background: 'black',
                 position: 'fixed',
-                padding: 20
+                padding: 20,
               }}
             >
               <h1>
@@ -238,7 +293,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 300,
           padding: 50,
           height: 300,
-          border: 'solid 1px red'
+          border: 'solid 1px red',
         }}
       >
         <ConnectedOverlay
@@ -249,7 +304,7 @@ storiesOf('Utilities|Overlay/Connected', module)
             <div
               style={{
                 background: 'black',
-                padding: 15
+                padding: 15,
               }}
             >
               <h1>Hello</h1>
@@ -270,7 +325,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 300,
           padding: 50,
           height: 300,
-          border: 'solid 1px red'
+          border: 'solid 1px red',
         }}
       >
         <ConnectedOverlay
@@ -281,7 +336,7 @@ storiesOf('Utilities|Overlay/Connected', module)
             <div
               style={{
                 background: 'black',
-                padding: 15
+                padding: 15,
               }}
             >
               <h1>Hello</h1>
@@ -303,7 +358,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           trigger="hover"
           placement="top"
           style={{
-            pointerEvents: 'none'
+            pointerEvents: 'none',
           }}
           open={open}
           content={() => (
@@ -313,7 +368,7 @@ storiesOf('Utilities|Overlay/Connected', module)
                 background: 'rgba(0, 0, 0, .5)',
                 color: 'white',
                 textAlign: 'center',
-                borderRadius: 5
+                borderRadius: 5,
               }}
               initial={{ opacity: 0, scale: 0.3 }}
               animate={{ opacity: 1, scale: 1 }}
@@ -342,7 +397,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 300,
           padding: 50,
           height: 300,
-          border: 'solid 1px red'
+          border: 'solid 1px red',
         }}
       >
         <Tooltip content="Hello">
@@ -364,7 +419,7 @@ storiesOf('Utilities|Overlay/Connected', module)
               padding: '5px 20px 5px 0',
               background: 'rgba(0, 0, 0, .5)',
               color: 'white',
-              borderRadius: 5
+              borderRadius: 5,
             }}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -386,7 +441,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 150,
           padding: 50,
           height: 150,
-          border: 'solid 1px red'
+          border: 'solid 1px red',
         }}
       >
         <button

--- a/src/Overlay/Overlay.story.tsx
+++ b/src/Overlay/Overlay.story.tsx
@@ -14,7 +14,7 @@ storiesOf('Utilities|Overlay/Portal', module)
     <div
       style={{
         width: 300,
-        height: 300,
+        height: 300
       }}
     >
       <div
@@ -24,7 +24,7 @@ storiesOf('Utilities|Overlay/Portal', module)
           background: 'black',
           padding: 50,
           position: 'relative',
-          overflow: 'hidden',
+          overflow: 'hidden'
         }}
       >
         Hello
@@ -49,7 +49,7 @@ storiesOf('Utilities|Overlay/Portal', module)
           background: 'black',
           padding: 50,
           position: 'relative',
-          overflow: 'hidden',
+          overflow: 'hidden'
         }}
       >
         Hello!
@@ -68,7 +68,7 @@ storiesOf('Utilities|Overlay/Global', module)
       <div
         style={{
           width: 300,
-          height: 300,
+          height: 300
         }}
       >
         <div
@@ -78,7 +78,7 @@ storiesOf('Utilities|Overlay/Global', module)
             background: 'black',
             padding: 50,
             position: 'relative',
-            overflow: 'hidden',
+            overflow: 'hidden'
           }}
         >
           Hello
@@ -88,7 +88,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 style={{
                   background: 'blue',
                   zIndex: overlayIndex,
-                  position: 'absolute',
+                  position: 'absolute'
                 }}
               >
                 Hi - {overlayIndex}
@@ -106,7 +106,7 @@ storiesOf('Utilities|Overlay/Global', module)
       <div
         style={{
           width: 300,
-          height: 300,
+          height: 300
         }}
       >
         <div
@@ -116,7 +116,7 @@ storiesOf('Utilities|Overlay/Global', module)
             background: 'black',
             padding: 50,
             position: 'relative',
-            overflow: 'hidden',
+            overflow: 'hidden'
           }}
         >
           <button type="button" onClick={() => setOpen(true)}>
@@ -132,7 +132,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 style={{
                   background: 'blue',
                   zIndex: overlayIndex,
-                  position: 'absolute',
+                  position: 'absolute'
                 }}
               >
                 Hi - {overlayIndex}
@@ -150,7 +150,7 @@ storiesOf('Utilities|Overlay/Global', module)
       <div
         style={{
           width: 300,
-          height: 300,
+          height: 300
         }}
       >
         <div
@@ -160,7 +160,7 @@ storiesOf('Utilities|Overlay/Global', module)
             background: 'black',
             padding: 50,
             position: 'relative',
-            overflow: 'hidden',
+            overflow: 'hidden'
           }}
         >
           <button type="button" onClick={() => setOpen(true)}>
@@ -181,7 +181,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 style={{
                   background: 'blue',
                   zIndex: overlayIndex,
-                  position: 'absolute',
+                  position: 'absolute'
                 }}
               >
                 Hi - {overlayIndex}
@@ -194,7 +194,7 @@ storiesOf('Utilities|Overlay/Global', module)
   })
   .add('Hooks', () => {
     const { GlobalOverlay, setOpen, overlayIndex } = useGlobalOverlay({
-      onClose: () => setOpen(false),
+      onClose: () => setOpen(false)
     });
 
     return (
@@ -209,7 +209,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 background: 'blue',
                 padding: 25,
                 zIndex: overlayIndex as number,
-                position: 'fixed',
+                position: 'fixed'
               }}
             >
               Hello!
@@ -229,7 +229,7 @@ storiesOf('Utilities|Overlay/Global', module)
             style={{
               display: 'flex',
               justifyContent: 'center',
-              alignItems: 'center',
+              alignItems: 'center'
             }}
           >
             <motion.div
@@ -243,7 +243,7 @@ storiesOf('Utilities|Overlay/Global', module)
                 top: 50,
                 background: 'black',
                 position: 'fixed',
-                padding: 20,
+                padding: 20
               }}
             >
               <h1>
@@ -293,7 +293,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 300,
           padding: 50,
           height: 300,
-          border: 'solid 1px red',
+          border: 'solid 1px red'
         }}
       >
         <ConnectedOverlay
@@ -304,7 +304,7 @@ storiesOf('Utilities|Overlay/Connected', module)
             <div
               style={{
                 background: 'black',
-                padding: 15,
+                padding: 15
               }}
             >
               <h1>Hello</h1>
@@ -325,7 +325,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 300,
           padding: 50,
           height: 300,
-          border: 'solid 1px red',
+          border: 'solid 1px red'
         }}
       >
         <ConnectedOverlay
@@ -336,7 +336,7 @@ storiesOf('Utilities|Overlay/Connected', module)
             <div
               style={{
                 background: 'black',
-                padding: 15,
+                padding: 15
               }}
             >
               <h1>Hello</h1>
@@ -358,7 +358,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           trigger="hover"
           placement="top"
           style={{
-            pointerEvents: 'none',
+            pointerEvents: 'none'
           }}
           open={open}
           content={() => (
@@ -368,7 +368,7 @@ storiesOf('Utilities|Overlay/Connected', module)
                 background: 'rgba(0, 0, 0, .5)',
                 color: 'white',
                 textAlign: 'center',
-                borderRadius: 5,
+                borderRadius: 5
               }}
               initial={{ opacity: 0, scale: 0.3 }}
               animate={{ opacity: 1, scale: 1 }}
@@ -397,7 +397,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 300,
           padding: 50,
           height: 300,
-          border: 'solid 1px red',
+          border: 'solid 1px red'
         }}
       >
         <Tooltip content="Hello">
@@ -419,7 +419,7 @@ storiesOf('Utilities|Overlay/Connected', module)
               padding: '5px 20px 5px 0',
               background: 'rgba(0, 0, 0, .5)',
               color: 'white',
-              borderRadius: 5,
+              borderRadius: 5
             }}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -441,7 +441,7 @@ storiesOf('Utilities|Overlay/Connected', module)
           width: 150,
           padding: 50,
           height: 150,
-          border: 'solid 1px red',
+          border: 'solid 1px red'
         }}
       >
         <button

--- a/src/Overlay/useGlobalOverlay.tsx
+++ b/src/Overlay/useGlobalOverlay.tsx
@@ -11,6 +11,7 @@ export interface GlobalOverlayCommon {
   closeOnBackdropClick?: boolean;
   hasBackdrop?: boolean;
   backdropClassName?: string;
+  onClose?: () => void;
 }
 
 export const useGlobalOverlay = (options?: GlobalOverlayCommon) => {
@@ -18,24 +19,25 @@ export const useGlobalOverlay = (options?: GlobalOverlayCommon) => {
     hasBackdrop = true,
     closeOnEscape = true,
     closeOnBackdropClick = true,
-    backdropClassName
+    backdropClassName,
+    onClose = () => undefined,
   } = options || {};
   const { OverlayPortal, ref, overlayIndex, portalIndex } = useOverlayPortal();
   const [open, setOpen] = useState<boolean>(false);
 
   const onBackdropClick = useCallback(() => {
     if (closeOnBackdropClick) {
-      setOpen(false);
+      onClose && onClose();
     }
-  }, [setOpen, closeOnBackdropClick]);
+  }, [closeOnBackdropClick]);
 
   useExitListener(ref, {
-    onEscape: () => closeOnEscape && setOpen(false)
+    onEscape: () => closeOnEscape && onClose && onClose(),
   });
 
   const Component = useCallback(
     ({ children }) => (
-      <OverlayContext.Provider value={{ close: () => setOpen(false) }}>
+      <OverlayContext.Provider value={{ close: () => onClose && onClose() }}>
         <AnimatePresence>
           {open && (
             <OverlayPortal>
@@ -64,6 +66,6 @@ export const useGlobalOverlay = (options?: GlobalOverlayCommon) => {
     isOpen: open,
     setOpen,
     ref,
-    GlobalOverlay: Component
+    GlobalOverlay: Component,
   };
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `open` prop passed to the overlay was only used as a default value of sorts to enable the overlay. Then the state changes within the internal component took over and it was impossible to cancel closing the overlay once `onClose` had been triggered (ie, you could not add a confirmation prompt).

Issue Number: N/A


## What is the new behavior?
`open` prop is synced with internal component state. `onClose` prop is called from the internal component instead of changing the internal `open` state.

## Does this PR introduce a breaking change?
```
[x] Yes - possibly
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If `onClose` prop was not passed in previously, the component incorrectly handled it before. Now, if onClose isn't passed in, the overlay will not be able to close. See story updates.

@amcdnl ☝️should `onClose` be a required prop instead?

## Other information
